### PR TITLE
Added laravel-elixir-browserify to extension list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,3 +214,4 @@ You'll find a number of Elixir extensions at [npmjs.org](https://www.npmjs.org/s
 
 - [Stylus](https://www.npmjs.org/package/laravel-elixir-stylus)
 - [Codeception](https://www.npmjs.org/package/laravel-elixir-codeception)
+- [Browserify](https://www.npmjs.org/package/laravel-elixir-browserify)


### PR DESCRIPTION
I created simple wrapper around browserify as elixir extension - I think this is better place for it than elixir core. I tried to make it simple as possible like rest of elixir tasks. 
