### PR TITLE
Workaround for a known bug in gulp-sass.

### DIFF
--- a/ingredients/sass.js
+++ b/ingredients/sass.js
@@ -24,7 +24,7 @@ elixir.extend('sass', function(src, output) {
 
     gulp.task('sass', function() {
         return gulp.src(src)
-            .pipe(sass({ outputStyle: config.production ? 'compressed' : 'nested' }))
+            .pipe(sass({ outputStyle: config.production ? 'compressed' : 'nested', sourceComments: 'normal' }))
                 .on('error', function(err) {
                     plugins.notify.onError({
                         title:    'Laravel Elixir',


### PR DESCRIPTION
gulp-sass will not compile .sass files without this option enabled. See https://github.com/dlmanning/gulp-sass/issues/55#issuecomment-47708591

> With default settings compiling sass files doesn't work. However there is a workaround. If you pass sourceComments: 'normal' as parameter the compilation work. The reason for this is that there is a strange condition which change how file are handled: https://github.com/dlmanning/gulp-sass/blob/master/index.js#L23-L27

**Reproduce**
Create a new .sass file with a simple test;

```
div
  margin: 10px
```

Add it to your gulpfile and run `gulp`.

It will error out with `Error: stdin:1: invalid top-level expression`
