### PR TITLE
Update GulpCssCompiler.js

### DIFF
--- a/ingredients/helpers/GulpCssCompiler.js
+++ b/ingredients/helpers/GulpCssCompiler.js
@@ -5,7 +5,7 @@ var config = require('laravel-elixir').config;
 module.exports = function(options) {
 
     var src = config.buildGulpSrc(
-        options.src, options.assetsDir, options.search
+        options.src, config.assetsDir, options.search
     );
 
     gulp.task(options.pluginName, function() {


### PR DESCRIPTION
Perhaps this is incorrect and temporary solution, but it solves the issue with src variable being returned with "undefined" prefix, e.g. [ 'undefined/resources/assets/less/site.less' ] which is probably some kind of search fault.

See this question: http://stackoverflow.com/questions/26500755/laravel-5-elixir-css-js-not-coming-into-public-directory-after-running-gulp-i
