### PR TITLE
Change to fix watched phpspec tasks from stopping after first Green

### DIFF
--- a/ingredients/helpers/Notification.js
+++ b/ingredients/helpers/Notification.js
@@ -10,7 +10,7 @@ module.exports = function() {
             subtitle: subtitle,
             icon: __dirname + '/../../icons/laravel.png',
             message: ' '
-        });
+        })();
     };
 
     this.error = function(e, subtitle) {


### PR DESCRIPTION
This is not a fix, but the issue is that when running `gulp tdd`, PHPUnit tasks work fine, but PHPSpec tasks only work ok until it first hits green, and from then on, phpspec never runs again.

In my change, phpspec tasks do not stop at the first green, and run again and show red when the tests fail again, however

1. Green does not appear as a notification; it's only shown in the console.
2. The console shows a bunch of errors.

Therefore, do _not_ use my fix, please make your own.

My guess is that my "fix" is the fact that an exception is thrown from the notify() call, and that allows the phpspec tasks to continue, otherwise for some reason the phpspec tasks get stuck at green for some reason.

A possible hint for why Red continues the tasks, but Green gets them stuck is if I read the gulp-notify documentation, for onError() calls, it says "onError() will automatically end the stream for you. Making it easer for watching.". Could the lack of ending the "stream" be a source of problems for regular notify() and Green?

I don't understand nodejs and gulp-notify too well, so I'm not able to help much more.