### PR TITLE
Fix MergeRequest.js to initialize this.search before it's used

### DIFF
--- a/ingredients/helpers/MergeRequest.js
+++ b/ingredients/helpers/MergeRequest.js
@@ -2,9 +2,9 @@ var utilities = require('./Utilities');
 
 var MergeRequest = function(files, baseDir, outputDir, ext) {
     this.baseDir = baseDir || 'public';
+    this.search = '**/*.' + ext;
     this.files = utilities.prefixDirToFiles(this.baseDir, files || this.search);
     this.type = ext;
-    this.search = '**/*.' + ext;
     this.concatFileName = 'all.' + ext;
 
     this.setOutputDir(outputDir);


### PR DESCRIPTION
this.search is used before it got initialized. throws an error on some platforms.
