### PR TITLE
Update watch and copy tasks to use name 'copy' instead of 'publish'.

### DIFF
--- a/ingredients/commands/CopyFiles.js
+++ b/ingredients/commands/CopyFiles.js
@@ -44,7 +44,7 @@ var parseDest = function(dest) {
 var buildTask = function() {
     var stream;
 
-    gulp.task('publish', function() {
+    gulp.task('copy', function() {
         config.duplicate.forEach(function(toCopy) {
             stream = gulp
                     .src(toCopy.src.path)
@@ -65,5 +65,5 @@ module.exports = function(src, dest) {
 
     buildTask();
 
-    return config.queueTask('publish');
+    return config.queueTask('copy');
 };

--- a/ingredients/watch.js
+++ b/ingredients/watch.js
@@ -8,7 +8,7 @@ var tasksToRun;
 
 gulp.task('watch', function() {
     srcPaths = config.watchers.default;
-    tasksToRun = _.intersection(config.tasks, _.keys(srcPaths).concat('publish'));
+    tasksToRun = _.intersection(config.tasks, _.keys(srcPaths).concat('copy'));
 
     inSequence.apply(this, tasksToRun.concat('watch-assets'));
 });


### PR DESCRIPTION
In b6d59b9f68978224064964a75a7639f95aa2eeee, the publish command was removed and a note made to use the copy command instead. Elixir is extended with the name 'copy', but it still registered with gulp as 'publish', so a 'gulp copy' wouldn't work. Now it does.