### PR TITLE
Fix Notification.js to work from notify-send in vagrant to terminal-notifier on osx.

### DIFF
--- a/ingredients/commands/Notification.js
+++ b/ingredients/commands/Notification.js
@@ -9,7 +9,7 @@ module.exports = function() {
             title: this.title,
             subtitle: subtitle,
             icon: __dirname + '/../../icons/laravel.png',
-            message: ' '
+            message: subtitle
         });
     };
 


### PR DESCRIPTION
Doesn't seem like subtitle is used when you use notify-send through vagrant to terminal-notifier on osx. Just just get a box with icon and "Laravel Elixir" title. No subtitle shown. When done like I do in this PR, it'll show the message underneath the title.

I think maybe it would be better with a function signature like:
```
this.message = function(message, subtitle) {
…
subtitle: subtitle || ' ',
message: message || ' '
…
```
It should be backwards compatible.
Would rather send file a bug report,  but since that's disabled this is the simplest fix I could think of.