### PR TITLE
Freeze gulp-minify-css to v0.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-if": "^1.2.5",
     "gulp-less": "^1.3.6",
     "gulp-load-plugins": "^0.7.0",
-    "gulp-minify-css": "^0.3.10",
+    "gulp-minify-css": "0.3.11",
     "gulp-notify": "^1.8.0",
     "gulp-phpspec": "^0.3.0",
     "gulp-phpunit": "^0.6.3",


### PR DESCRIPTION
There were some breaking changes introduced in `v0.3.12` that breaks tasks. Freeze to `v0.3.11` to avoid errors until this is fixed.

See the discussion at https://github.com/jonathanepollack/gulp-minify-css/issues/61#issuecomment-71432208