### PR TITLE
version method should wait while deleting.

### DIFF
--- a/ingredients/version.js
+++ b/ingredients/version.js
@@ -21,8 +21,8 @@ elixir.extend('version', function(src, buildDir) {
     buildDir = buildDir ? buildDir + '/build' : 'public/build';
 
     gulp.task('version', function() {
-        del(buildDir + '/*', { force: true }, function() {
-            return gulp.src(src, { base: './public' })
+        del.sync(buildDir + '/*', { force: true });
+        return gulp.src(src, { base: './public' })
                 .pipe(gulp.dest(buildDir))
                 .pipe(rev())
                 .pipe(gulp.dest(buildDir))


### PR DESCRIPTION
The `version()` method empties and re-creates the build folder. All right.
But if you attach any task after `version()` related with the "build" folder (or its children), it will throw you an error because the "build" folder doesn't exist yet (it's deleting).

One example : 
In my case, I want to create symlinks in the "public/build" folder. I've made my own Elixir extends named `symlinks()`.
I have something like : 
```
mix.
// some tasks...
.version([
       'public/assets/styles.css',
        'public/assets/scripts.js'
]).symlinks([
        {src: 'app/assets/fonts', dest:'public/build/assets/fonts'},
        {src: 'app/assets/img', dest:'public/build/assets/img'}
]);
```
I had errors (ENOENT) because it couldn't create the symlink : "public/build/..." didn't exist yet. 
This solution make it works fine.