### PR TITLE
set default baseDir to elixir.config.assetsDir+js

### DIFF
--- a/ingredients/scripts.js
+++ b/ingredients/scripts.js
@@ -15,6 +15,7 @@ var MergeRequest = require('./commands/MergeRequest');
 
 elixir.extend('scripts', function(scripts, outputDir, baseDir) {
     outputDir = outputDir || elixir.config.jsOutput;
+    baseDir = baseDir || elixir.config.assetsDir + 'js';
 
     return combine(mergeRequest(scripts, outputDir, baseDir));
 });


### PR DESCRIPTION
MergeRequest use fix "resources/" if baseDir not defined.
It would be better the elixir.config.assetsDir + 'js'