### PR TITLE
set default baseDir to elixir.config.assetsDir+css

### DIFF
--- a/ingredients/styles.js
+++ b/ingredients/styles.js
@@ -15,6 +15,7 @@ var MergeRequest = require('./commands/MergeRequest');
 
 elixir.extend('styles', function(styles, outputDir, baseDir) {
     outputDir = outputDir || elixir.config.cssOutput;
+    baseDir = baseDir || elixir.config.assetsDir + 'css';
 
     return combine(mergeRequest(styles, outputDir, baseDir));
 });


### PR DESCRIPTION
MergeRequest use fix "resources/" if baseDir not defined.
It would be better the elixir.config.assetsDir + 'css'