### PR TITLE
Feature plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
-var Elixir = function(recipe) {
+"use strict";
+
+var loadPlugins = require('gulp-load-plugins');
+
+var Elixir = function (recipe) {
     require('require-dir')('./ingredients');
     recipe(Elixir.config);
 };
 
 Elixir.config = require('./Config');
 Elixir.config.setDefaultsFrom('elixir.json');
+Elixir.$ = loadPlugins();
 
-Elixir.extend = function(name, callback) {
+Elixir.extend = function (name, callback) {
     Elixir.config[name] = callback;
 };
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var Elixir = function (recipe) {
 
 Elixir.config = require('./Config');
 Elixir.config.setDefaultsFrom('elixir.json');
-Elixir.$ = loadPlugins();
+Elixir.plugins = loadPlugins();
+Elixir._ = require('underscore');
 
 Elixir.extend = function (name, callback) {
     Elixir.config[name] = callback;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-filter": "^1.0.2",
     "gulp-if": "^1.2.5",
     "gulp-less": "^1.3.6",
-    "gulp-load-plugins": "^0.7.0",
+    "gulp-load-plugins": "^0.8.1",
     "gulp-minify-css": "^0.3.10",
     "gulp-notify": "^1.8.0",
     "gulp-phpspec": "^0.3.0",


### PR DESCRIPTION
Hey, I often find myself requiring gulp plugins when they're already available in elixir. 
With this change you'd be able to require these plugins like this:

```javascript
var gulp = require('gulp'), 
    elixir = require('laravel-elixir'),
    $ = elixir.plugins;

elixir.extend('...', function (src, out, opts) {
    return gulp.src('*.css').pipe($.autoprefixer()).pipe(gulp.dest('out.css'));
});
```

I do understand that in rare cases the creator of a laravel elixir plugin might want to use a more bleeding edge version of a gulp plugin that elixir uses. In that case he'd still be able to do that by simple requiring it. I do find that I often have no need for this.

With this commit I bumped up the gulp-load-plugins version and included a few lines that make some libraries shared (the gulp plugins and underscore)
As a sidenote: is there any particular reason why you prefer underscore over lodash?