### PR TITLE
added async tasks

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -51,6 +51,30 @@ config.queueTask = function(task) {
 
 
 /**
+ * @callback elixirRecipe
+ * @param  {object} mix - Elixir config object
+ */
+
+/**
+ * Add asynchronous group of tasks.
+ *
+ * @param {elixirRecipe} recipe - function applied with elixir config element
+ */
+config.asyncGroup = function (recipe) {
+    var queue = this.tasks,
+        asyncQueue = [];
+
+    // Push to asyncQueue
+    this.tasks = asyncQueue;
+    recipe(this);
+
+    // Add to tasks
+    queue.push(asyncQueue);
+    this.tasks = queue;
+    return this;
+};
+
+/**
  * Set the default directory paths.
  *
  * @param {string} file


### PR DESCRIPTION
Hello,

I thought it be cool to have a feature where we can specify which tasks can be ran asynchronous. This can be done using run-sequence. I created a function _asyncGroup_ that takes a function as a parameter, just like elixir does. So that within that function you can basically define your tasks the same way you would define them usually. 

A small illustration: 

```javascript
elixir(function (mix) {
  mix.browserify('**/app.js')
    .asyncGroup(function (mix) {
      mix.imagemin()
        .stylesIn('css');
    })
    .scriptsIn('css_vendor')
```

This would result in your Elixir.config.tasks object being equal to: 

```
[
  'browserify',
  ['imagemin', 'styles'],
  'scripts'
]
```

Since this is a feature that run-sequence offers. I think it's a nice thing to have.