### PR TITLE
Feature: copying files without renaming them

### DIFF
--- a/ingredients/commands/CopyFiles.js
+++ b/ingredients/commands/CopyFiles.js
@@ -48,7 +48,7 @@ var buildTask = function() {
         config.duplicate.forEach(function(toCopy) {
             stream = gulp
                     .src(toCopy.src.path)
-                    .pipe(gulpif( ! toCopy.src.isDir, rename(toCopy.dest.basename)))
+                    .pipe(gulpif(toCopy.rename && ! toCopy.src.isDir, rename(toCopy.dest.basename)))
                     .pipe(gulp.dest(toCopy.dest.path));
         });
 
@@ -57,10 +57,11 @@ var buildTask = function() {
 };
 
 
-module.exports = function(src, dest) {
+module.exports = function(src, dest, rename) {
     config.duplicate.push({
         src: parseSrc(src),
-        dest: parseDest(dest)
+        dest: parseDest(dest),
+        rename: rename
     });
 
     buildTask();

--- a/ingredients/copy.js
+++ b/ingredients/copy.js
@@ -13,6 +13,10 @@ var config = elixir.config;
  |
  */
 
+elixir.extend('copyFiles', function (source, destination) {
+    return copy(source, destination, false);
+});
+
 elixir.extend('copy', function(source, destination) {
-    return copy(source, destination);
+    return copy(source, destination, true);
 });


### PR DESCRIPTION
Hey, I tried to use the copy task to copy some files today. They got renamed for some reason so I went digging and noticed this is indeed the case.

Perhaps I'm missing something, in which case, please do tell! But I already went ahead and created something that fits my needs:

In my particular case:
```javascript
mix.copyFiles(paths.select2 + '*.{png,gif}', 'public/css');
```

The old behavior gave me a file called 'css' in _public/css_.
You might have a different implementation solution but with this pull request I'm letting you know I stumbled onto this and my solution worked for me personally