### PR TITLE
Version does not use same src for watcher and build task

### DIFF
--- a/ingredients/version.js
+++ b/ingredients/version.js
@@ -20,7 +20,8 @@ var parsePath = require('parse-filepath');
 
 elixir.extend('version', function(src, buildDir) {
     buildTask(src, buildDir);
-
+    
+    src = utilities.prefixDirToFiles('public', src);
     this.registerWatcher('version', src);
 
     return this.queueTask('version');


### PR DESCRIPTION
src for registerWatcher differs from src for buildTask, meaning it never updates unless you restart gulp watch process