### PR TITLE
Watches all files that are "copied".

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -28,8 +28,9 @@ config.registerWatcher = function(task, search, group) {
     group = group || 'default';
 
     this.watchers[group] = this.watchers[group] || {};
+    this.watchers[group][task] = this.watchers[group][task] || [];
 
-    this.watchers[group][task] = search;
+    this.watchers[group][task].push(search);
 
     return this;
 }

--- a/ingredients/copy.js
+++ b/ingredients/copy.js
@@ -14,5 +14,6 @@ var config = elixir.config;
  */
 
 elixir.extend('copy', function(source, destination) {
+    this.registerWatcher("copy", source);
     return copy(source, destination);
 });


### PR DESCRIPTION
Hi there!

My gulp file runs the "copy" task/command multiple times to copy various asset files to the public directory. However, "gulp watch" doesn't seem to be monitoring any of them for changes. This makes things a bit error prone during development when I change an asset file but forget to run gulp.

Here's a quick patch that makes "gulp watch" monitor all copied files/directories for changes.