### PR TITLE
Allow an actual buildDir to be set and only delete versioned files

### DIFF
--- a/ingredients/version.js
+++ b/ingredients/version.js
@@ -55,6 +55,9 @@ var buildTask = function(src, buildDir) {
             .on('end', function() {
                 // Copy over relevant sourcemap files.
                 copyMaps(src, buildDir);
+
+                // Delete pre-versioned files
+                deletePreVersionedFiles(src, buildDir);
             });
     });
 };
@@ -96,7 +99,11 @@ var copyMaps = function(src, buildDir) {
         var map = mapping.replace('public', buildDir);
 
         if (map !== mapping) {
-            gulp.src(mapping).pipe(gulp.dest(parsePath(map).dirname));
+            gulp.src(mapping)
+                .pipe(gulp.dest(parsePath(map).dirname))
+                .on('end', function() {
+                    del.sync(mapping);
+                });
         }
     });
 };
@@ -117,3 +124,22 @@ var deletePreviousVersion = function (buildDir) {
         }
     }
 };
+
+/**
+ * Deletes original files that were versioned
+ *
+ * @param  {string} src
+ * @param  {string} buildDir
+ */
+var deletePreVersionedFiles = function (src, buildDir) {
+    for (var i in src) {
+        var file = src[i],
+            duplicateCopy = file.replace('public', buildDir);
+
+        del.sync(file, {force: true});
+
+        if (fs.existsSync(duplicateCopy)) {
+            del.sync(duplicateCopy, {force: true});
+        }
+    }
+}


### PR DESCRIPTION
This is in response to #66 

This is my first nodejs change so I'm expecting it to need updating, it also removes some previous 'features' in the default instance.

Whatever is passed as the second parameter to `version` is now used, as-is, for the build path (no `/build` is appended). This allows the files to be created wherever someone might want them.

Only files that are defined within the `rev-manifest.json` file are deleted now. Since it's possible to put the files in any folder we can't just delete everything because things will go missing (as I learnt while developing this). This does mean that if you're using the default setup that empty folders won't get deleted, but it's highly likely they would just've been re-created anyway.

The duplicated `app.css` files that would be created by the versioning aren't cleaned up after the versioning. They aren't deleted at the start when deleting the pervious versioned files since it's possible that we wouldn't be deleting the duplicated file but the original.

Map files are only copied if the new location doesn't match the old location.