### PR TITLE
Modify the copy task to support multiple files/directories

### DIFF
--- a/ingredients/commands/CopyFiles.js
+++ b/ingredients/commands/CopyFiles.js
@@ -15,7 +15,7 @@ var parseSrc = function(src) {
     var path = parsePath(src);
     var isDir = (path.basename == path.name);
 
-   return _.extend(path, {
+    return _.extend(path, {
         path: src + (isDir ? '/**/*' : ''),
         isDir: isDir
     });

--- a/ingredients/commands/CopyFiles.js
+++ b/ingredients/commands/CopyFiles.js
@@ -58,9 +58,13 @@ var buildTask = function() {
 
 
 module.exports = function(src, dest) {
-    config.duplicate.push({
-        src: parseSrc(src),
-        dest: parseDest(dest)
+    src = Array.isArray(src) ? src : [src];
+
+    src.forEach(function(src) {
+        config.duplicate.push({
+            src: parseSrc(src),
+            dest: parseDest(dest)
+        });
     });
 
     buildTask();


### PR DESCRIPTION
##### I think it would be useful to pass an array as source to the copy task.

For example, if you need to copy the fonts of many vendors, it would be better to do it like this:
```javascript
var fonts = [
	'path_to_bootstrap/fonts',
	'path_to_fontawesome/fonts',
	...
];

mix.copy(fonts, 'public/fonts');
```

Instead of this:
```javascript
mix.copy(
	'path_to_bootstrap/fonts',
	'public/fonts'
)
.copy(
	'path_to_fontawesome/fonts',
	'public/fonts'
);
```