### PR TITLE
Allow watch-assets task to run callbacks

### DIFF
--- a/ingredients/watch.js
+++ b/ingredients/watch.js
@@ -15,6 +15,10 @@ gulp.task('watch', function() {
 
 gulp.task('watch-assets', function() {
     for (var task in srcPaths) {
-        gulp.watch(srcPaths[task], [task]);
+        if (_.isFunction(srcPaths[task])) {
+            srcPaths[task].apply(this);
+        } else {
+            gulp.watch(srcPaths[task], [task]);
+        }
     }
 });


### PR DESCRIPTION
Allows watch-assets task to run custom callbacks. Useful for integrating browserify along with watchify (which is a special watch task).

Related: #81 