### PR TITLE
Normalize file path before checking whether it exists, remove fs.exists in favor of fs.open

### DIFF
--- a/ingredients/commands/Utilities.js
+++ b/ingredients/commands/Utilities.js
@@ -79,6 +79,8 @@ var assertFilesExist = function(files) {
 		file = path.normalize(file);
 		fs.open(file, 'r', function (error, fd) {
 			if (error != null) {
+				if (error.code !== 'ENOENT') throw error;
+
 				logMissingFile(file);
 				return;
 			}

--- a/ingredients/commands/Utilities.js
+++ b/ingredients/commands/Utilities.js
@@ -1,5 +1,6 @@
 var gutil = require('gulp-util');
-var fs = require('fs');
+var fs = require('fs'),
+	path = require('path');
 
 /**
  * Build up the given src file(s), to be passed to Gulp.
@@ -74,11 +75,16 @@ var assertFilesExist = function(files) {
         // paths that areregular expressions.
         if(/\*/.test(file)) return;
 
-        fs.exists(file, function(found) {
-            if ( ! found) {
-                logMissingFile(file);
-            }
-        });
+		// Normalize path first
+		file = path.normalize(file);
+		fs.open(file, 'r', function (error, fd) {
+			if (error != null) {
+				logMissingFile(file);
+				return;
+			}
+
+			fs.close(fd);
+		});
     });
 };
 


### PR DESCRIPTION
Just a quick commit. Shouldn't break anything but does add some extra functionality

Imagine a path:
```
/tmp/sass/../css/app.scss
```
This will fail in case the sass directory doesn't exist, yet sass will still execute if /tmp/css/app.scss exists.
I think they should either both fail or it shouldn't log an error. My commit does just that.

path.normalize basically converts above path to /tmp/css/app.scss and then checks whether it exists or not.

I also used fs.exists myself a few days ago and I noticed it's going to be deprecated so I went ahead and replaced it with what the docs say you should do when checking for file existence which is open a file in read mode and check for errors.

EDIT: made it so that it throws the error in cases of different errors.