### PR TITLE
Add the option to split browserify bundle.js

### DIFF
--- a/ingredients/browserify.js
+++ b/ingredients/browserify.js
@@ -1,4 +1,4 @@
-var utilities = require('laravel-elixir/ingredients/commands/Utilities');
+var utilities = require('./commands/Utilities');
 var source = require('vinyl-source-stream');
 var parsePath = require('parse-filepath');
 var browserify = require('browserify');

--- a/ingredients/browserify.js
+++ b/ingredients/browserify.js
@@ -1,11 +1,11 @@
-var utilities = require('./commands/Utilities');
+var utilities = require('laravel-elixir/ingredients/commands/Utilities');
 var source = require('vinyl-source-stream');
 var parsePath = require('parse-filepath');
 var browserify = require('browserify');
 var elixir = require('laravel-elixir');
+var factor = require('factor-bundle');
 var babelify = require('babelify');
 var gulp = require('gulp');
-
 
 /**
  * Calculate the correct destination.
@@ -37,12 +37,32 @@ var getDestination = function(output) {
 var buildTask = function(src, output, options) {
     var destination = getDestination(output);
 
+    // log and pause
+    var onError = function(e) {
+      console.error('Browserify failed: '+ e);
+      console.log(e.codeFrame);
+      this.emit('end');
+    };
+
     gulp.task('browserify', function() {
-        return browserify(src, options)
-            .transform(babelify, { stage: 0 })
-            .bundle()
-            .pipe(source(destination.saveFile))
-            .pipe(gulp.dest(destination.saveDir));
+        var b = browserify(src, options);
+        b.transform(babelify, { stage: 0 });
+
+        // Split files in to seperate files with a common
+        if(options.splitFiles) {
+          options.splitFiles = options.splitFiles.map(function(file){
+            return destination.saveDir +'/'+ file;
+          });
+          b.plugin(factor, {
+              // File output order must match entry order
+              output: options.splitFiles
+            });
+        }
+
+        b.bundle()
+          .on('error', onError)
+          .pipe(source(destination.saveFile))
+          .pipe(gulp.dest(destination.saveDir));
     });
 };
 
@@ -62,9 +82,14 @@ elixir.extend('browserify', function(src, output, baseDir, options) {
     var search = '/**/*.+(js|jsx|babel)';
 
     baseDir = baseDir || 'resources/js';
-    src = utilities.buildGulpSrc(src, './' + baseDir, search);
     output = output || this.jsOutput;
     options = options || {};
+
+    // If split files isset set the source as new files or user defined
+    if(options.splitFiles) {
+      options.splitFiles = (options.splitFiles === true) ? src : options.splitFiles;
+    }
+    src = utilities.buildGulpSrc(src, './' + baseDir, search);
 
     utilities.logTask('Running Browserify', src);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "babelify": "^6.0.0",
     "browserify": "^9.0.4",
+    "factor-bundle": "^2.4.0",
     "del": "^0.1.3",
     "gulp-autoprefixer": "^1.0.1",
     "gulp-coffee": "^2.2.0",


### PR DESCRIPTION
Creates the option to split the bundle.js into multiple files with a common file e.g.
```js
elixir(function(mix) {
  mix.browserify(['page-1.js', 'page-2.js'], null, null, { splitFiles: true });
});
```
would become `page-1.js`, `page-2.js` and `bundle.js`
When creating multiple react/flux projects on a bigger website you don't want to load all react components on all pages.
SplitFiles can take true or an array with new filenames

This also fixes crash on error #116