### PR TITLE
allow exclude files with prefix !

### DIFF
--- a/ingredients/commands/Utilities.js
+++ b/ingredients/commands/Utilities.js
@@ -27,9 +27,13 @@ var prefixDirToFiles = function(dir, files) {
     if ( ! Array.isArray(files)) files = [files];
 
     return files.map(function(file) {
-        file = file.replace(dir, '');
-
-        return [dir, file].join('/').replace('//', '/');
+        var isExclude = (file.indexOf('!') === 0);
+        file = file.replace(new RegExp('^!?(' + dir + ')?'), '');
+        file = [dir, file].join('/').replace('//', '/');
+        if (isExclude) {
+            file = '!' + file;
+        }
+        return file;
     });
 };
 

--- a/ingredients/commands/Utilities.js
+++ b/ingredients/commands/Utilities.js
@@ -27,13 +27,9 @@ var prefixDirToFiles = function(dir, files) {
     if ( ! Array.isArray(files)) files = [files];
 
     return files.map(function(file) {
-        var isExclude = (file.indexOf('!') === 0);
-        file = file.replace(new RegExp('^!?(' + dir + ')?'), '');
-        file = [dir, file].join('/').replace('//', '/');
-        if (isExclude) {
-            file = '!' + file;
-        }
-        return file;
+        return file
+            .replace(new RegExp('^(!?)('+dir+')?'), '$1'+dir+'/')
+            .replace('//', '/');
     });
 };
 


### PR DESCRIPTION
Currently when we add 
```js
mix.scripts([
    'resources/assets/app/**/*.module.js',
    'resources/assets/app/**/*.js',
    '!resources/assets/app/**/*.spec.js',
], 'public/js/app.js', './')
```
elixir will change :

```
  '!resources/assets/app/**/*.spec.js'

to 

./!resources/assets/app/**/*.spec.js
```
This is not correct. So please use my fix.

it will convert that path to 

```
!./resources/assets/app/**/*.spec.js
```