### PR TITLE
Update dependency for gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^2.0.0",
     "gulp-ruby-sass": "^1.0.1",
-    "gulp-sass": "^1.1.0",
+    "gulp-sass": "^2.0.0",
     "gulp-shell": "^0.2.9",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.1",


### PR DESCRIPTION
Gulp-sass dependency (1.1) is rather old. 2.0 in turn bumps node-sass to 3.0.0 and libsass to 3.2.x, bringing these tools up-to-date and libsass close to feature parity with ruby sass 3.4.