### PR TITLE
Resolves #10

### DIFF
--- a/ingredients/commands/Utilities.js
+++ b/ingredients/commands/Utilities.js
@@ -27,7 +27,7 @@ var prefixDirToFiles = function(dir, files) {
     if ( ! Array.isArray(files)) files = [files];
 
     return files.map(function(file) {
-        file = file.replace(dir, '');
+        file = file.replace(new RegExp('^' + dir), '');
 
         return [dir, file].join('/').replace('//', '/');
     });


### PR DESCRIPTION
This instead replaces the directory name at the *beginning* of strings rather throughout the string, so that path name containing "public" will not be modified (for example, public/public_website.js will now become public_website.js rather than website.js).