### PR TITLE
#116 browserify and errors

### DIFF
--- a/ingredients/browserify.js
+++ b/ingredients/browserify.js
@@ -8,6 +8,7 @@ var uglify = require('gulp-uglify');
 var babelify = require('babelify');
 var gulpIf = require('gulp-if');
 var gulp = require('gulp');
+var Notification = require('./commands/Notification');
 
 
 /**
@@ -40,10 +41,17 @@ var getDestination = function(output) {
 var buildTask = function(src, output, options) {
     var destination = getDestination(output);
 
+    var onError = function(e) {
+        new Notification().error(e, 'Browserify Bundling Failed!');
+
+        this.emit('end');
+    };
+
     gulp.task('browserify', function() {
         return browserify(src, options)
             .transform(babelify, { stage: 0 })
             .bundle()
+            .on('error', onError)
             .pipe(source(destination.saveFile))
             .pipe(buffer())
             .pipe(gulpIf(elixir.config.production, uglify()))


### PR DESCRIPTION
Notify Browserify errors (just like the coffee ingredient) and stop Browserify crashing Gulp.