### PR TITLE
Added scriptOptions parameter to scripts and scriptsIn ingredients

### DIFF
--- a/ingredients/commands/MergeFiles.js
+++ b/ingredients/commands/MergeFiles.js
@@ -76,7 +76,7 @@ var mergeFileSet = function (set, request) {
     return gulp.src(set.files)
                .pipe(plugins.if(config.sourcemaps, plugins.sourcemaps.init()))
                .pipe(plugins.concat(set.concatFileName))
-               .pipe(plugins.if(request.taskName === 'scripts' && config.babel.enabled, babel(config.babel.options)))
+               .pipe(plugins.if(request.taskName === 'scripts' && config.babel.enabled && set.scriptOptions.compileEs6, babel(config.babel.options)))
                .pipe(plugins.if(config.production, request.minifier.call(this)))
                .pipe(plugins.if(config.sourcemaps, plugins.sourcemaps.write('.')))
                .pipe(gulp.dest(set.outputDir));

--- a/ingredients/scripts.js
+++ b/ingredients/scripts.js
@@ -13,23 +13,24 @@ var MergeRequest = require('./commands/MergeRequest');
  |
  */
 
-elixir.extend('scripts', function(scripts, outputDir, baseDir) {
+elixir.extend('scripts', function(scripts, outputDir, baseDir, scriptOptions) {
     outputDir = outputDir || elixir.config.jsOutput;
 
-    return combine(mergeRequest(scripts, outputDir, baseDir));
+    return combine(mergeRequest(scripts, outputDir, baseDir, scriptOptions));
 });
 
-elixir.extend('scriptsIn', function(baseDir, outputDir) {
+elixir.extend('scriptsIn', function(baseDir, outputDir, scriptOptions) {
     outputDir = outputDir || baseDir;
 
-    return combine(mergeRequest('**/*.js', outputDir, baseDir));
+    return combine(mergeRequest('**/*.js', outputDir, baseDir, scriptOptions));
 });
 
-var mergeRequest = function(scripts, outputDir, baseDir) {
+var mergeRequest = function(scripts, outputDir, baseDir, scriptOptions) {
     var request = new MergeRequest(scripts, baseDir, outputDir, 'js');
 
     request.taskName = 'scripts';
     request.minifier = require('gulp-uglify');
+    request.scriptOptions = scriptOptions || {};
 
     return request;
 };


### PR DESCRIPTION
Adding `{compileEs6: true}` as the last parameter to `.scripts()` or `.scriptsIn()` will selectively enable compiling ES6 script with Babel on a case-by-case basis.

An attempt to resolve #154.