### PR TITLE
Move browserify transforms into stream definition

### DIFF
--- a/ingredients/browserify.js
+++ b/ingredients/browserify.js
@@ -38,7 +38,12 @@ var getDestination = function(output) {
  * @param {object}       options
  */
 var browserifyStream = function(src, options) {
-    return browserify(src, options);
+    var stream = browserify(src, options);
+
+    stream.transform(babelify, { stage: 0 });
+    stream.transform(partialify);
+
+    return stream;
 };
 
 
@@ -75,8 +80,6 @@ var buildTask = function() {
 
             bundle = function(stream) {
                 return stream
-                    .transform(babelify, { stage: 0 })
-                    .transform(partialify)
                     .bundle()
                     .on('error', function(e) {
                         new Notification().error(e, 'Browserify Failed!');


### PR DESCRIPTION
I'm not sure of the root cause - somewhere between 1.x and 2.x - but while watching, browserify transformation times would get exponentially worse.  Moving the options into the stream definition resolved the issue.  Unsure if partialify would have a similar problem, but moving for the sake of consistency.

Details are here: http://stackoverflow.com/questions/29653204/watchify-w-gulp-and-babel-gets-progressively-slower