### PR TITLE
fix for multiple calls to mix.browserify() #103

### DIFF
--- a/ingredients/browserify.js
+++ b/ingredients/browserify.js
@@ -37,8 +37,8 @@ var getDestination = function(output) {
  * @param {string|array} src
  * @param {object}       options
  */
-var browserifyStream = function(src, options) {
-    var stream = browserify(src, options);
+var browserifyStream = function(data) {
+    var stream = browserify(data.src, data.options);
 
     stream.transform(babelify, { stage: 0 });
     stream.transform(partialify);
@@ -53,12 +53,12 @@ var browserifyStream = function(src, options) {
  * @param {string|array} src
  * @param {object}       options
  */
-var watchifyStream = function(src, options) {
-    var browserify = watchify(browserifyStream(src, options));
+var watchifyStream = function(data) {
+    var browserify = watchify(browserifyStream(data));
 
     browserify.on('log', gutil.log);
     browserify.on('update', function() {
-        bundle(browserify);
+        bundle(browserify, data);
     });
 
     return browserify;
@@ -76,9 +76,9 @@ var buildTask = function() {
             : browserifyStream;
 
         return merge.apply(this, dataSet.map(function(data) {
-            utilities.logTask('Running Browserify', data.src);
 
-            bundle = function(stream) {
+            bundle = function(stream, data) {
+                utilities.logTask('Running Browserify', data.src);
                 return stream
                     .bundle()
                     .on('error', function(e) {
@@ -91,8 +91,8 @@ var buildTask = function() {
                     .pipe(gulp.dest(data.destination.dir));
             }
 
-            return bundle(stream(data.src, data.options));
-        }));
+             return bundle(stream(data), data);
+        }));;
     });
 };
 


### PR DESCRIPTION
The main problem was that the bundle function holds always the last data passed in from `dataSet.map`

now the knows the stream about the data and keeps passing the right once to `bundle`

for issue #103