### PR TITLE
enable customizing browserify transforms

### DIFF
--- a/ingredients/browserify.js
+++ b/ingredients/browserify.js
@@ -38,10 +38,13 @@ var getDestination = function(output) {
  * @param {object}       options
  */
 var browserifyStream = function(data) {
-    var stream = browserify(data.src, data.options);
 
-    stream.transform(babelify, { stage: 0 });
-    stream.transform(partialify);
+    data.options.transform = data.options.transform || [
+        [babelify, { stage: 0 }],
+        partialify
+    ];
+
+    var stream = browserify(data.src, data.options);
 
     return stream;
 };


### PR DESCRIPTION
All the transforms that were speicified using the transform option were always applied before babelify and partialify, which is not always desirable because the parser will throw errors if you use ES6 features.