### PR TITLE
Fix watch for multiple tasks with the same name and race condition

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -97,6 +97,29 @@ var config = {
 
     sourcemaps: true,
 
+    /*
+     |----------------------------------------------------------------
+     | File system events batching options for watch task
+     |----------------------------------------------------------------
+     |
+     | Imagine case when when gulp task A updates multiple files in some folder F.
+     | If there is another task B which observes changes in folder F,
+     | watch will call task B as many times, as many files was changed.
+     | This is definitely a problem for some tasks where multiple instances can't run in parallel
+     | because they generate and delete files after themselves.
+     | Good example of such command is an Elixir version command.
+     | To solve this issue we should batch consecutive file system update events
+     | which came during the config.batch.timeout period and call functions only once.
+     |
+     | For more information about options see https://github.com/floatdrop/gulp-batch#batchoptions-callback-errorhandler
+     |
+     */
+
+    batchOptions: {
+        limit: undefined,
+        timeout: 1000
+    },
+
     css: {
 
         /*

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "del": "^1.2.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-babel": "^5.1.0",
+    "gulp-batch": "^1.0.5",
     "gulp-coffee": "^2.3.1",
     "gulp-concat": "^2.6.0",
     "gulp-if": "^1.2.5",


### PR DESCRIPTION
This pull request fixes 2 issues.
1. Because of this code https://github.com/laravel/elixir/blob/6a6a68829e861f2320ec64f9840340a82b9278a5/tasks/watch.js#L35 elixir creates gulp watcher only for first task with the same. All the watchers (globs) from other tasks with the same name will be ignored. I.e. if you have calls like `mix.scripts(glob1, ...).scripts(glob2, ...).scripts(glob3, ...)` with current implementation next gulp watcher will be generated: `gulp.watch(glob3, [task.name]);`  
2. Race condition issue:
Imagine case when when gulp task A updates multiple files in some folder F.
If there is another task B which observes changes in folder F,
watch will call task B as many times, as many files was changed.
This is definitely a problem for some tasks where multiple instances can't run in parallel
because they generate and delete files after themselves.
Good example of such command is an Elixir version command.
To solve this issue we should batch consecutive file system update events
which came during the config.batch.timeout period and call functions only once.

For more information see https://github.com/floatdrop/gulp-batch#batchoptions-callback-errorhandler
