### PR TITLE
Use glob to find sourcemaps & added gulp rev replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp-phpunit": "^0.8.4",
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^5.1.0",
+    "gulp-rev-replace": "^0.4.2",
     "gulp-sass": "^2.0.3",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babelify": "^6.1.3",
     "browserify": "^10.2.6",
     "del": "^1.2.0",
+    "glob": "^5.0.14",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-babel": "^5.1.0",
     "gulp-coffee": "^2.3.1",

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -6,8 +6,8 @@ var rev = require('gulp-rev');
 var Elixir = require('laravel-elixir');
 var vinylPaths = require('vinyl-paths');
 var parsePath  = require('parse-filepath');
-
 var publicPath  = Elixir.config.publicPath;
+var revReplace = require('gulp-rev-replace');
 
 
 /*
@@ -32,11 +32,16 @@ Elixir.extend('version', function(src, buildPath) {
 
         emptyBuildPathFiles(paths.output.baseDir, manifest);
 
+        // We need to remove the publicPath from the output base to get the
+        // correct prefix path.
+        var filePathPrefix = paths.output.baseDir.replace(publicPath, '') + '/';
+
         return (
             gulp.src(paths.src.path, { base: './' + publicPath })
             .pipe(gulp.dest(paths.output.baseDir))
             .pipe(files)
             .pipe(rev())
+            .pipe(revReplace({prefix: filePathPrefix}))
             .pipe(gulp.dest(paths.output.baseDir))
             .pipe(rev.manifest())
             .pipe(gulp.dest(paths.output.baseDir))

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var del = require('del');
+var glob = require("glob");
 var gulp = require('gulp');
 var rev = require('gulp-rev');
 var Elixir = require('laravel-elixir');
@@ -97,23 +98,30 @@ var emptyBuildPathFiles = function(buildPath, manifest) {
  * @return {object}
  */
 var copyMaps = function(src, buildPath) {
-    // We'll first get any files from the src
-    // array that have companion .map files.
-    var mappings = [];
-
     src.forEach(function(file) {
-        var map = file + '.map';
+        // We'll first get any files from the src
+        // array that have companion .map files.
+        glob(file, {}, function(err, files) {
+            if (err === null) {
+                // Here we will store the mappings.
+                var mappings = [];
 
-        if (fs.existsSync(map)) {
-            mappings.push(map);
-        }
-    });
+                // Loop over each file found by glob
+                // and check if a map for that file exists.
+                files.forEach(function(file) {
+                    var map = file + '.map';
+                    if (fs.existsSync(map)) {
+                        mappings.push(map);
+                    }
+                });
 
-    // And then we'll loop over this mapping array
-    // and copy each over to the build directory.
-    mappings.forEach(function(mapping) {
-        var map = mapping.replace(publicPath, buildPath);
-
-        gulp.src(mapping).pipe(gulp.dest(parsePath(map).dirname));
+                // And then we'll loop over this mapping array
+                // and copy each over to the build directory.
+                mappings.forEach(function(mapping) {
+                    var map = mapping.replace(publicPath, buildPath);
+                    gulp.src(mapping).pipe(gulp.dest(parsePath(map).dirname));
+                });
+            }
+        });
     });
 };


### PR DESCRIPTION
This adds one fix and a new addition, because i didn't know pushing another commit to my fork would add it to this pr (i wanted to create two PRs :disappointed:) If there an easy way to undo this i'd gladly do it, but i don't know how; since i'm kinda new to contributing.

--

When using a glob pattern to version files the companion maps cannot
be found because `fs.existsSync()` does not support glob. This will
use glob to find files and then check if a map exists.

For instance now if you have a gulp file like below source maps will not be 
copied because we're using a glob pattern.
```javascript
elixir(function(mix) {
    mix.version([
            'public/css/*.css',
            'public/js/*.js',
            'public/img/**/*.{jpg,jpeg,gif,png}'
        ]);
});
```

When you are using `mix.version()` to also rev static assets like
images, and you are reverencing these images inside your css you
will get an incorrect path in your css. Revving images will generate
a file like `logo-8f311dc3ed.png`. Since the references in your css
will not be replaced this will result in 404 on the resource.

For instance, your css:
```css
.logo {
    background-image: 'img/logo.png';
    // Actual file is called logo-8f311dc3ed.png because of mix.version()
}
```

This will use [gulp-rev-replace](https://github.com/jamesknelson/gulp-rev-replace) to replaced the original paths
with the correct revved file path.