### PR TITLE
Add phpUnit configurationFile option

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -331,7 +331,8 @@ var config = {
             // https://www.npmjs.com/package/gulp-phpunit#api
             options: {
                 debug: true,
-                notify: true
+                notify: true,
+                configurationFile: 'phpunit.xml'
             }
         },
 


### PR DESCRIPTION
for gulp-phpunit.

Fixes #229 once https://github.com/mikeerickson/gulp-phpunit/pull/26 is merged.

A recent gulp-phpunit commit gives priority to gulp.src() files for generating the specific command to run.  In this case 'config.testing.phpUnit.path + '/**/*Test.php' was given causing the error to fire as phpunit is looking for an xml file.  

While gulp-phpunit has an option to use a file path string set on option.configurationFile, Elixir did not have this option set, and gulp-phpunit would ignore that completely anyway with the priority this way.

With my commit to gulp-phpunit the configurationFile will take priority as long it is set for gulp-phpunit's options..