### PR TITLE
Upgrade gulp-phpunit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-minify-css": "^1.2.0",
     "gulp-notify": "^2.2.0",
     "gulp-phpspec": "^0.5.3",
-    "gulp-phpunit": "^0.8.4",
+    "gulp-phpunit": "0.9.0",
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^5.1.0",
     "gulp-rev-replace": "^0.4.2",


### PR DESCRIPTION
This upgrades gulp-phpunit to 0.9.0 to resolve the issue described in #229.

This allows `mix.phpUnit();` to work without passing in 'phpunit.xml', and it also allows `gulp tdd` to work properly in watching both `tests/**/*Test.php` and `app/**/*.php`.