### PR TITLE
Add support for Browserify plugins

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -266,6 +266,8 @@ var config = {
             // https://www.npmjs.com/package/browserify#usage
             options: {},
 
+            plugins: [],
+
             transformers: [
                 {
                     name: 'babelify',

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -96,6 +96,12 @@ var browserifyStream = function(data) { // just use two arguments
         );
     });
 
+    config.js.browserify.plugins.forEach(function(plugin) {
+        stream.plugin(
+            require(plugin.name), plugin.options || {}
+        );
+    });
+
     return stream;
 };
 


### PR DESCRIPTION
Usage example:
```js
elixir.config.js.browserify.plugins.push({
    name: 'css-modulesify',
    options: {
      output: 'public/css/main.css'
    }
});
```