### PR TITLE
Add error handler for babel

### DIFF
--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -66,6 +66,10 @@ var gulpTask = function(paths, babel) {
         .pipe($.if(config.sourcemaps, $.sourcemaps.init()))
         .pipe($.concat(paths.output.name))
         .pipe($.if(babel, $.babel(babel)))
+        .on('error', function(e) {
+            new Elixir.Notification().error(e, 'Babel Compilation Failed!');
+            this.emit('end');
+        })
         .pipe($.if(config.production, $.uglify()))
         .pipe($.if(config.sourcemaps, $.sourcemaps.write('.')))
         .pipe(gulp.dest(paths.output.baseDir))


### PR DESCRIPTION
Catch babel errors killing gulp watch

Already patched once by @JeffreyWay but lost:
https://github.com/laravel/elixir/commit/331141daa7f437b7e318a886e2c1f638442a8d20