### PR TITLE
Negate patterns on paths

### DIFF
--- a/GulpPaths.js
+++ b/GulpPaths.js
@@ -105,7 +105,14 @@ GulpPaths.prototype.prefix = function(path, prefix) {
             return path;
         }
 
-        return p.join(prefix, path)
+        // If path starts with "!" we need to negate him
+        if (path.indexOf('!') == 0) {
+            path = '!' + p.join(prefix, path.substring(1));
+        } else {
+            path = p.join(prefix, path);
+        }
+
+        return path.replace(/\/\//g, '/')
             .replace(/\/\//g, '/')
             .replace(p.join(prefix, prefix), prefix);
     };


### PR DESCRIPTION
When working with recursive patterns sometimes we need to negate some files/patterns, like so:

    mix.scripts([
        '!plugins/**/-*.js',
        'plugins/**/*.js',
        'main.js'
    ]);

With this kind of patterns I accept all files inside plugins folder, except if the file start with a dash.

gulp.src() already do this work, but prefix one doesn't

Related Link:
- http://stackoverflow.com/a/24648667