### PR TITLE
Allow to add external references to browserify stream

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -268,6 +268,8 @@ var config = {
 
             plugins: [],
 
+            externals: [],
+
             transformers: [
                 {
                     name: 'babelify',

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -102,6 +102,10 @@ var browserifyStream = function(data) { // just use two arguments
         );
     });
 
+    config.js.browserify.externals.forEach(function(external) {
+        stream.external(external);
+    });
+
     return stream;
 };
 


### PR DESCRIPTION
Allow to specify which libraries should not be included in browserify builds so they can be provided externally, i.e.: vendor.js.