### PR TITLE
Fixed two issues with browserSync

### DIFF
--- a/tasks/browsersync.js
+++ b/tasks/browsersync.js
@@ -23,8 +23,12 @@ Elixir.extend('browserSync', function (options) {
             config.appPath + '/**/*.php',
             config.get('public.css.outputFolder') + '/**/*.css',
             config.get('public.js.outputFolder') + '/**/*.js',
+            config.get('public.versioning.buildFolder') + '/rev-manifest.json',
             'resources/views/**/*.php'
-        ]
+        ],
+        watchOptions: {
+            usePolling: true
+        }
     }, options);
 
     // Browsersync will only run during `gulp watch`.


### PR DESCRIPTION
- With some Node installations (including the most recent laravel/homestead vagrant box) file watching did not work properly.
- Versioned files using the 'elixir' blade function weren't being updated realtime due to the /public/build/ folder not being watched.