### PR TITLE
Use precision of 10 by default for SASS task

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -196,7 +196,8 @@ var config = {
             pluginOptions: {
                 outputStyle: gutils.env.production
                     ? 'compressed'
-                    : 'nested'
+                    : 'nested',
+                precision: 10
             }
         },
 


### PR DESCRIPTION
The default in SASS is 5.  Bootstrap (bootstrap-sass included with laravel by default) utilizes a `$line-height-base` of `1.428571429`.  The default precision rounds this to `1.42857`.  This doesn't cause many noticeable issues, but does cause input groups with buttons (`input-group-btn`) to be misaligned.  Issue is described [here](https://github.com/twbs/bootstrap-sass/issues/409)