### PR TITLE
Versioning Path Prefix breaks on Windows

### DIFF
--- a/tasks/version.js
+++ b/tasks/version.js
@@ -8,6 +8,7 @@ var vinylPaths = require('vinyl-paths');
 var parsePath  = require('parse-filepath');
 var publicPath  = Elixir.config.publicPath;
 var revReplace = require('gulp-rev-replace');
+var path = require('path');
 
 
 /*
@@ -34,7 +35,11 @@ Elixir.extend('version', function(src, buildPath) {
 
         // We need to remove the publicPath from the output base to get the
         // correct prefix path.
-        var filePathPrefix = paths.output.baseDir.replace(publicPath, '') + '/';
+        var unixPrefix = paths.output.baseDir;
+        if (path.sep !== '/') {
+            unixPrefix = unixPrefix.split(path.sep).join('/');
+        }
+        var filePathPrefix = unixPrefix.replace(publicPath, '') + '/';
 
         return (
             gulp.src(paths.src.path, { base: './' + publicPath })


### PR DESCRIPTION
I've found that on windows you can end up with a url with backslashes in it because the paths.output contains the OS dir separator. This PR swaps the dir separator for the unix one.

Note - I am assuming that people use only unix paths for public path, but if not could need to switch the order so the dir separator replacement is done after that swap

