### PR TITLE
Added the option to use globbing paths on SCSS files

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -183,6 +183,21 @@ var config = {
 
         /*
          |----------------------------------------------------------------
+         | Sass/CSS Globbing
+         |----------------------------------------------------------------
+         |
+         | When working with so many Sass or CSS files you can use wildcards 
+         | to import them. Adding @import 'partials/*' you will import 
+         | all Sass/CSS files in partials folder.
+         |
+         */
+        globbing: {
+            // https://github.com/jsahlen/gulp-css-globbing
+            extensions: ['.css', '.scss', '.sass']
+        },
+
+        /*
+         |----------------------------------------------------------------
          | Sass Compilation
          |----------------------------------------------------------------
          |

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-batch": "^1.0.5",
     "gulp-coffee": "^2.3.1",
     "gulp-concat": "^2.6.0",
+    "gulp-css-globbing": "^0.1.8",
     "gulp-if": "^1.2.5",
     "gulp-less": "^3.0.3",
     "gulp-load-plugins": "^1.0.0-rc.1",

--- a/tasks/shared/Css.js
+++ b/tasks/shared/Css.js
@@ -1,5 +1,6 @@
-var gulp   = require('gulp');
-var Elixir = require('../../index');
+var gulp    = require('gulp');
+var cssGlob = require('gulp-css-globbing');
+var Elixir  = require('../../index');
 
 var $ = Elixir.Plugins;
 var config = Elixir.config;
@@ -13,6 +14,7 @@ module.exports = function(options) {
     return (
         gulp
         .src(options.src.path)
+        .pipe(cssGlob({ extensions: ['.css', '.scss', '.sass'] }))
         .pipe($.if(config.sourcemaps, $.sourcemaps.init()))
         .pipe(options.compiler(options.pluginOptions))
         .on('error', function(e) {

--- a/tasks/shared/Css.js
+++ b/tasks/shared/Css.js
@@ -1,6 +1,5 @@
-var gulp    = require('gulp');
-var cssGlob = require('gulp-css-globbing');
-var Elixir  = require('../../index');
+var gulp   = require('gulp');
+var Elixir = require('../../index');
 
 var $ = Elixir.Plugins;
 var config = Elixir.config;
@@ -14,7 +13,7 @@ module.exports = function(options) {
     return (
         gulp
         .src(options.src.path)
-        .pipe(cssGlob({ extensions: ['.css', '.scss', '.sass'] }))
+        .pipe($.cssGlobbing(config.css.globbing))
         .pipe($.if(config.sourcemaps, $.sourcemaps.init()))
         .pipe(options.compiler(options.pluginOptions))
         .on('error', function(e) {


### PR DESCRIPTION
I think that would be useful for styles files organization. I used the gulp-css-globbing plugin, it works with CSS too.
We will use @import 'partials/*'; to import all partials without declare each one.