### PR TITLE
browsersync support for dd function

### DIFF
--- a/tasks/browsersync.js
+++ b/tasks/browsersync.js
@@ -28,6 +28,14 @@ Elixir.extend('browserSync', function (options) {
         ],
         watchOptions: {
             usePolling: true
+        },
+        snippetOptions: {
+            rule: {
+                match: /(<\/body>|<\/pre>)/i,
+                fn: function (snippet, match) {
+                    return snippet + match;
+                }
+            }
         }
     }, options);
 


### PR DESCRIPTION
Overriding default browsersync function with </pre> tag support to make browsersync js embeddable on dd output.