### PR TITLE
Load the sourcemaps generated in browserify

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -43,7 +43,7 @@ Elixir.extend('browserify', function(src, output, baseDir, options) {
                 })
                 .pipe(source(paths.output.name))
                 .pipe(buffer())
-                .pipe($.if(config.sourcemaps, $.sourcemaps.init()))
+                .pipe($.if(config.sourcemaps, $.sourcemaps.init({ loadMaps: true })))
                 .pipe($.if(config.production, $.uglify()))
                 .pipe($.if(config.sourcemaps, $.sourcemaps.write('.')))
                 .pipe(gulp.dest(paths.output.baseDir))


### PR DESCRIPTION
Instead of using the source maps generated in browserify, the task is creating a sourcemap for a file which already has a sourcemap.