### PR TITLE
Revert "fixed coffee, less, sass watching"

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -16,9 +16,9 @@ var config = Elixir.config;
  */
 
 Elixir.extend('coffee', function(src, output, options) {
-    var paths = prepGulpPaths(src, output);
-
     new Elixir.Task('coffee', function() {
+        var paths = prepGulpPaths(src, output);
+
         this.log(paths.src, paths.output);
 
         return (
@@ -38,8 +38,7 @@ Elixir.extend('coffee', function(src, output, options) {
             .pipe(new Elixir.Notification('CoffeeScript Compiled!'))
         );
     })
-    .watch(paths.src.path)
-    .ignore(paths.output.path);
+    .watch(config.get('assets.js.coffee.folder') + '/**/*.coffee')
 });
 
 

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -16,9 +16,9 @@ var config = Elixir.config;
  */
 
 Elixir.extend('less', function(src, output, options) {
-    var paths = prepGulpPaths(src, output);
-
     new Elixir.Task('less', function() {
+        var paths = prepGulpPaths(src, output);
+
         return compile({
             name: 'Less',
             compiler: require('gulp-less'),
@@ -28,8 +28,7 @@ Elixir.extend('less', function(src, output, options) {
             pluginOptions: options || config.css.less.pluginOptions
         });
     })
-    .watch(paths.src.path)
-    .ignore(paths.output.path);
+    .watch(config.get('assets.css.less.folder') + '/**/*.less');
 });
 
 /**

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -16,9 +16,9 @@ var config = Elixir.config;
  */
 
 var gulpTask = function(src, output, options) {
-    var paths = prepGulpPaths(src, output);
-
     new Elixir.Task('sass', function() {
+        var paths = prepGulpPaths(src, output);
+
         return compile({
             name: 'Sass',
             compiler: require('gulp-sass'),
@@ -28,8 +28,7 @@ var gulpTask = function(src, output, options) {
             pluginOptions: options || config.css.sass.pluginOptions
         });
     })
-    .watch(paths.src.path)
-    .ignore(paths.output.path);
+    .watch(config.get('assets.css.sass.folder') + '/**/*.+(sass|scss)');
 };
 
 


### PR DESCRIPTION
Reverts laravel/elixir#362

If app.scss in 
`@import "base";`
and then gulpfile.js contain 
`mix.sass('app.scss')` 
and run 
`gulp watch`
then if base.scss changed, elixir/gulp no compiled new file...
If ONLY app.scss changed, then compile new file... :(

Thanks!