### PR TITLE
Keep original files when using publicPath in versioning

### DIFF
--- a/tasks/version.js
+++ b/tasks/version.js
@@ -47,8 +47,11 @@ Elixir.extend('version', function(src, buildPath) {
             .on('end', function() {
                 // We'll get rid of the duplicated file that
                 // usually gets put in the "build" folder,
-                // alongside the suffixed version.
-                del(files.paths, { force: true });
+                // alongside the suffixed version, just if
+                // buildFolder is different than publicPath
+                if (isExternalBuildPath(buildPath)) {
+                    del(files.paths, { force: true });
+                }
 
                 // We'll also copy over relevant sourcemap files.
                 copyMaps(paths.src.path, paths.output.baseDir);
@@ -119,3 +122,15 @@ var copyMaps = function(src, buildPath) {
         });
     });
 };
+
+/**
+ * Returns true if buildPath is different from publicPath, instead returns false
+ * @param buildPath
+ * @returns {boolean}
+ */
+var isExternalBuildPath = function(buildPath) {
+    var customBuildPath = buildPath || config.get('public.versioning.buildFolder');
+
+    return customBuildPath !== Elixir.config.publicPath;
+};
+


### PR DESCRIPTION
This pull request is simply fixing the mistake that was made in #328. Issac incorrectly used the assetPath rather than publicPath in his pull request, and is yet to correct it. Everything else is exactly the same and all credit for the change should go to @isaacperaza. 

This fix is for situations where the version output directory has been overridden like so:
```
var versionFiles = [
	'public/assets/css/application.css', 
	'public/assets/js/application.js',
	'public/assets/img/**/*.*'
];

elixir(function(mix) {
    mix.version(versionFiles, 'public');
});
```

The current behavior removes the original files from the public directory, leaving only the versioned files in place. This change will result in both the original and versioned files being kept side-by-side:
```
public
└─ css
 └─ application.css
 └─ application-8fa778f76c.css
└─ img
...
└─ js
 └─ application.js
 └─ application-676f8ea6c9.js
└─ rev-manifest.json
```
Another benefit of this change is that the filtering for the directories to version can be made less specific/complex, i.e. `public/assets/img` can be used rather than `public/assets/img/**/*.*` and the full directory structure will still be supported.

The Laravel framework doesn't currently support the override of the buildPath anyway, but for those of us who have overridden that behavior (like myself) or those who don't use Laravel, I think it's worthwhile improving the way the override works considering that we've got it.