### PR TITLE
Only apply 'safe' optimisations in cssnano

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -190,7 +190,9 @@ var config = {
 
         cssnano: {
             // http://cssnano.co/options
-            pluginOptions: {}
+            pluginOptions: {
+                safe: true
+            }
         },
 
         /*


### PR DESCRIPTION
This PR enables the "safe" option by default for the cssnano plugin.

From the [cssnano site](http://cssnano.co/options/):

> **options.safe (bool)**
> 
> Set this to true to disable advanced optimisations that are not always safe. Currently, this disables custom identifier reduction, z-index rebasing, unused at-rule removal & conversion between absolute length values.

According to the [cssnano readme](https://github.com/ben-eb/cssnano), this will be the default behaviour in cssnano v4 and above. In the meantime, setting this as a default in Elixir should help avoid issues like #412 and #420.