### PR TITLE
Move UglifyJS config to Config.js

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -285,6 +285,25 @@ var config = {
 
         /*
          |----------------------------------------------------------------
+         | UglifyJS Parser/Compressor/Beautifier
+         |----------------------------------------------------------------
+         |
+         | UglifyJS is a JavaScript parser/compressor/beautifier.
+         | It'll minify your JavaScript with ease and has an option to
+         | mangle your code.
+         |
+         */
+
+        uglify: {
+            options: {
+                compress: {
+                    drop_console: true
+                }
+            }
+        },
+
+        /*
+         |----------------------------------------------------------------
          | Browserify Compilation
          |----------------------------------------------------------------
          |

--- a/elixir-test-app/test/scripts.js
+++ b/elixir-test-app/test/scripts.js
@@ -1,0 +1,63 @@
+var fs     = require('fs');
+var gulp   = require('gulp');
+var remove = require('rimraf');
+var Elixir = require('laravel-elixir');
+
+
+describe('Scripts Task', function() {
+
+    beforeEach(() => {
+        Elixir.tasks = Elixir.config.tasks = [];
+    });
+
+    it('merges scripts together', function(done) {
+        Elixir(mix => mix.scripts(['lib1.js', 'lib2.js']));
+
+        runGulp(() => {
+            shouldExist('public/js/all.js');
+
+            done();
+        });
+    });
+
+    it('merges to any file the user wishes', function(done) {
+        Elixir(mix => mix.scripts(['lib1.js', 'lib2.js'], './public/js/merged.js'));
+
+        runGulp(() => {
+            shouldExist('public/js/merged.js');
+
+            done();
+        });
+    });
+
+    it('applies a custom base directory', function(done) {
+        Elixir(mix => {
+            // We'll copy files over to a custom directory to test this.
+            mix.copy('./resources/assets/js', './resources/assets/scripts');
+
+            mix.scripts(['lib1.js', 'lib2.js'], null, './resources/assets/scripts');
+        });
+
+        runGulp(() => {
+            shouldExist('public/js/all.js');
+
+            done();
+        });
+    });
+
+});
+
+
+var shouldExist = (file) => {
+    return fs.existsSync(file).should.be.true;
+};
+
+
+var runGulp = assertions => {
+    gulp.start('default', () => {
+        assertions();
+
+        remove.sync('./public/js');
+        remove.sync('./resources/assets/scripts');
+    });
+};

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -66,7 +66,7 @@ var gulpTask = function(paths, babel) {
             new Elixir.Notification().error(e, 'Babel Compilation Failed!');
             this.emit('end');
         })
-        .pipe($.if(config.production, $.uglify({compress: { drop_console: true }})))
+        .pipe($.if(config.production, $.uglify(config.js.uglify.options)))
         .pipe($.if(config.sourcemaps, $.sourcemaps.write('.')))
         .pipe(gulp.dest(paths.output.baseDir))
         .pipe(new Elixir.Notification('Scripts Merged!'))


### PR DESCRIPTION
With this change it's possible to change the UglifyJS configuration. This is necessary for certain projects where you want to turn off the mangle option.

I also added a test for the script task  to test if the changes I made broke something. All test still pass :+1: 

See issue #409 