### PR TITLE
Add cache and package cache browserify options keys by default

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -315,7 +315,10 @@ var config = {
 
         browserify: {
             // https://www.npmjs.com/package/browserify#usage
-            options: {},
+            options: {
+                cache: {},
+                packageCache: {}
+            },
 
             plugins: [],
 


### PR DESCRIPTION
See the `watchify` docs entry here: https://github.com/substack/watchify#watchifyb-opts

In order to allow `watchify` to utilize the `browserify` cache for fast rebuilds, the `cache` and `packageCache` options key must be set to empty objects.