### PR TITLE
elixir.copy() - support  if folder or filename start with dot charactor

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -22,7 +22,7 @@ Elixir.extend('copy', function(src, output) {
 
         return (
             gulp
-            .src(paths.src.path)
+            .src(paths.src.path, { dot: true })
             .pipe($.if(! paths.output.isDir, $.rename(paths.output.name)))
             .pipe(gulp.dest(paths.output.baseDir))
         );


### PR DESCRIPTION
Hi Legend Jeffery,

I'm a big fan of your laracasts.  This is my very first pull request, please correct me if i'm wrong 

Support dot in filename or folder (if it is first character) in `elixir.copy() ` e.g. `bower_components/select2/.bower.json`

please see more detail about  option  `{dot :true}` at node-glob -> Dots   https://github.com/isaacs/node-glob


maybe related to this issue https://github.com/laravel/elixir/issues/438


Thanks you.