### PR TITLE
Disable autoprefixing by cssnano.

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -191,6 +191,7 @@ var config = {
         cssnano: {
             // http://cssnano.co/options
             pluginOptions: {
+                autoprefixer: false,
                 safe: true
             }
         },


### PR DESCRIPTION
This autoprefixer step doesn't use the same settings set in `css.autoprefixer.options` and was generating different prefixes between the dev and production (minified) css builds. By disabling this it ensures the same prefixes are generated for both environments using the same config options.