### PR TITLE
Remove all comments during CSS minification

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -191,6 +191,7 @@ var config = {
         cssnano: {
             // http://cssnano.co/options
             pluginOptions: {
+                discardComments: { removeAll: true },
                 autoprefixer: false,
                 safe: true
             }


### PR DESCRIPTION
Related to #446. This little change makes sure that our production styles don't have any unnecessary comments.