### PR TITLE
Feature/custom css minifier

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -187,6 +187,10 @@ var config = {
          | reduced file sizes. Adjust any plugin option here.
          |
          */
+         
+        minifier: function (options, plugins, config) {
+            return plugins.cssnano(config.css.cssnano.pluginOptions);
+        },
 
         cssnano: {
             // http://cssnano.co/options

--- a/tasks/shared/Css.js
+++ b/tasks/shared/Css.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
         })
         .pipe($.if(config.css.autoprefix.enabled, $.autoprefixer(config.css.autoprefix.options)))
         .pipe($.concat(options.output.name))
-        .pipe($.if(config.production, $.cssnano(config.css.cssnano.pluginOptions)))
+        .pipe($.if(config.production, config.css.minifier.apply(options)))
         .pipe($.if(config.sourcemaps, $.sourcemaps.write('.')))
         .pipe(gulp.dest(options.output.baseDir))
         .pipe(new Elixir.Notification(name + ' Compiled!'))

--- a/tasks/shared/Css.js
+++ b/tasks/shared/Css.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
         })
         .pipe($.if(config.css.autoprefix.enabled, $.autoprefixer(config.css.autoprefix.options)))
         .pipe($.concat(options.output.name))
-        .pipe($.if(config.production, config.css.minifier.apply(options)))
+        .pipe($.if(config.production, config.css.minifier.apply(this, [options, $, config])))
         .pipe($.if(config.sourcemaps, $.sourcemaps.write('.')))
         .pipe(gulp.dest(options.output.baseDir))
         .pipe(new Elixir.Notification(name + ' Compiled!'))


### PR DESCRIPTION
This pull request gives the option to choose your perferred css minifier/compressor.

Personally I perfer the Clean CSS library as it performs better ([CSS minification benchmark](http://goalsmashers.github.io/css-minification-benchmark/)) and does a better job. One of the features I like is the combining of media queries.

With this pull request I can just add a small modification to my gulpfile:

```
elixir.config.css.minifier = function (options, plugins, config) {
    var cleanCSS = require('gulp-clean-css');

    return cleanCSS();
};
```

This modification doesn't break the current usage as it provides a default configuration with cssnano.