### PR TITLE
Gulp PhpUnit Fix for Windows

### DIFF
--- a/src/tasks/phpunit.js
+++ b/src/tasks/phpunit.js
@@ -1,5 +1,6 @@
 import runTests from './shared/Tests';
 
+var path = require('path');
 /*
  |----------------------------------------------------------------
  | PHPUnit Testing
@@ -15,6 +16,6 @@ Elixir.extend('phpUnit', function(src, command) {
     runTests(
         'PHPUnit',
         src || (Elixir.config.testing.phpUnit.path + '/**/*Test.php'),
-        command || 'vendor/bin/phpunit --verbose'
+        command || (path.normalize('vendor/bin/phpunit') + ' --verbose')
     );
 });


### PR DESCRIPTION
Wrapped the path used to call phpunit from gulp with path.normalize.  This makes gulp able to run phpUnit from Windows.  Haven't tested to ensure this didn't break anything for mac or linux, but hopefully it should be pretty safe.