### PR TITLE
Fix error handling when compiling CSS and JS

### DIFF
--- a/src/tasks/conductors/CssTask.js
+++ b/src/tasks/conductors/CssTask.js
@@ -22,7 +22,7 @@ class CssTask extends Elixir.Task {
             .src(this.src.path)
             .pipe(this.initSourceMaps())
             .pipe(this.compile())
-            .on('error', this.onError)
+            .on('error', this.onError())
             .pipe(this.autoPrefix())
             .pipe(this.concat())
             .pipe(this.minify())

--- a/src/tasks/conductors/JavaScriptTask.js
+++ b/src/tasks/conductors/JavaScriptTask.js
@@ -29,7 +29,7 @@ class JavaScriptTask extends Elixir.Task {
             gulp
             .src(this.src.path)
             .pipe(this.webpack())
-            .on('error', this.onError)
+            .on('error', this.onError())
             .pipe(this.minify())
             .pipe(this.saveAs(gulp))
             .pipe(this.onSuccess())


### PR DESCRIPTION
I cloned the master branch because I wanted to start playing with the Webpack integration and discovered that the error handling was broken. So, here's a fix. :)

~~Aside 1: CSS minification appears to also be broken but I haven't figured that one out yet.~~ See #527
Aside 2: Compiling requires `babel-preset-es2015` but it's not in the devDependencies. Intentional?