### PR TITLE
Allowing you to override publicPath in version

### DIFF
--- a/src/tasks/version.js
+++ b/src/tasks/version.js
@@ -1,4 +1,3 @@
-let publicPath  = Elixir.config.publicPath;
 let fs;
 let del;
 let glob;
@@ -17,7 +16,8 @@ let revReplace;
  |
  */
 
-Elixir.extend('version', function(src, buildPath) {
+Elixir.extend('version', function(src, buildPath, options) {
+    const publicPath = (options || {}).publicPath || Elixir.config.publicPath;
     const paths = prepGulpPaths(src, buildPath);
 
     loadPlugins();


### PR DESCRIPTION
I'm hoping to address two issues with this pull request
- I like to keep the public directory clean of intermediate results.
- I am migrating a rails codebase, so I want assets not to have a high level directory (/assets/application.css, not /assets/css/application.css)

The workflow I'm doing is as follows
- Create a tmp/assets
- Compile js + css => tmp/asset-compile/application.*
- Copy over all images into that directory as well
- Run the version task, with the publicDirectory as tmp/asset-compile, and the output directory as /assets
- tmp/asset-compile/assets is now the root with the rev-manifest.json

You can see a sample gulp file here: https://github.com/quintype/pina-colada/blob/master/gulpfile.js
