### PR TITLE
Catch JS minifier errors

### DIFF
--- a/src/tasks/conductors/JavaScriptTask.js
+++ b/src/tasks/conductors/JavaScriptTask.js
@@ -31,6 +31,7 @@ class JavaScriptTask extends Elixir.Task {
             .pipe(this.webpack())
             .on('error', this.onError())
             .pipe(this.minify())
+            .on('error', this.onError())
             .pipe(this.saveAs(gulp))
             .pipe(this.onSuccess())
         );


### PR DESCRIPTION
I ran into a Webpack bug that's generating invalid code. I didn't realize this until I ran gulp with the `--production` flag. This caused UglifyJS to spit out an error without displaying the error message — just the type and stack trace. This ended up killing the gulp process.

So, I fixed the problem with gulp being killed. :)

Notes:
- I added the second on error line because the first one is still required. If removed, Webpack errors will kill the gulp process.
- I put up an example repo that you can use to trigger the behavior I saw: https://github.com/thecrypticace/elixir-webpack-error
- Might this also apply to the CSS task as well?

Now I just gotta submit an issue to Webpack for its bug if one isn't already around.