### PR TITLE
Make .env variables available within the processed files (.js, .css, …

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean-css": "^3.4.12",
     "cli-table": "^0.3.1",
     "del": "^2.2.0",
+    "dotenv": "^2.0.0",
     "glob": "^7.0.3",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-batch": "^1.0.5",
@@ -56,7 +57,8 @@
     "vinyl-map": "^1.0.1",
     "vinyl-paths": "^2.1.0",
     "webpack": "^2.1.0-beta",
-    "webpack-stream": "^3.2.0"
+    "webpack-stream": "^3.2.0",
+    "gulp-preprocess": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,9 @@ function init() {
     if (! Elixir.config.notifications) {
         process.env.DISABLE_NOTIFIER = true;
     }
+    
+    //Load Env variables from .env
+    require('dotenv').config({silent: true});
 
     Elixir.Notification = require('./Notification').default;
 };

--- a/src/tasks/CssTask.js
+++ b/src/tasks/CssTask.js
@@ -21,6 +21,7 @@ class CssTask extends Elixir.Task {
         return (
             gulp
             .src(this.src.path)
+            .pipe(this.dotEnvPreprocess())
             .pipe(this.initSourceMaps())
             .pipe(this.compile())
             .on('error', this.onError())

--- a/src/tasks/JavaScriptTask.js
+++ b/src/tasks/JavaScriptTask.js
@@ -29,6 +29,7 @@ class JavaScriptTask extends Elixir.Task {
         return (
             gulp
             .src(this.src.path)
+             .pipe(this.dotEnvPreprocess())
             .pipe(this.webpack())
             .on('error', this.onError())
             .pipe(this.minify())

--- a/src/tasks/Task.js
+++ b/src/tasks/Task.js
@@ -1,5 +1,6 @@
 import map from 'vinyl-map';
 import minifier from './utilities/minifier';
+import preprocess from  'gulp-preprocess';
 
 class Task {
 
@@ -256,6 +257,13 @@ class Task {
      */
     stream() {
         return map(function () {});
+    }
+
+    /**
+     * Environment variables preprocessor
+     */
+    dotEnvPreprocess() {
+        return preprocess({context: process.env});
     }
 }
 


### PR DESCRIPTION
Hi,

Several times I needed to use environment-dependent variables inside sass or js files. Therefore, I used an environment variable preprocessor "jas/gulp-preprocess" plus a dotEnv reader "motdotla/dotenv" to read .env file. The result, I can use .env variables this way:

Inside sass file:

`$img-path: '/* @echo MY_CDN_URL */';`

Or inside js:

`var FacebookAppId = '/* @echo FACEBOOK_APP_ID */';`
`// @ifdef DEBUG
someDebuggingCall()
// @endif`

I don't know if this the right way to do this ! anyway, I like it :D . I hope you like it too :D.

Best Regards.