### PR TITLE
add babel-preset-es2015 as devDependecy

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,7 @@
 src/
 elixir-test-app/
+.idea/
+*.log
+todo.txt
+*.sublime-*
+

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
+    "babel-preset-es2015": "^6.9.0",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
     "mocha": "^2.4.5",


### PR DESCRIPTION
The preset is used in `compile` script, but it isn't declared as dependency so it isn't installed when run `npm install`.

The `compile` script is run on `prepublish` and the `publish` script is automatically run on `install`, causing the `npm install` to fail.