### PR TITLE
Downgrade buble dependency to fit buble-loadeder peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/laravel/elixir",
   "dependencies": {
     "browser-sync": "^2.12.3",
-    "buble": "^0.8.4",
+    "buble": "^0.7.0",
     "buble-loader": "^0.2.1",
     "clean-css": "^3.4.12",
     "cli-table": "^0.3.1",


### PR DESCRIPTION
Related Issue #551 

I'm afraid I haven't been able to run tests on this one. Have issues making `npm test` work. 
Any help here would be very much appreciated. (I'm @ikoolik at larachat Slack)