### PR TITLE
Rename 'GLOBAL' to 'global'.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-GLOBAL.gulp = require('gulp');
-GLOBAL.parse = require('parse-filepath');
+global.gulp = require('gulp');
+global.parse = require('parse-filepath');
 
 
 let GulpBuilder = require('./tasks/GulpBuilder').default;
@@ -10,7 +10,7 @@ let GulpBuilder = require('./tasks/GulpBuilder').default;
  *
  * @param {Function} recipe
  */
-GLOBAL.Elixir = recipe => {
+global.Elixir = recipe => {
     // 1. Perform any last-minute initialization.
     init();
 


### PR DESCRIPTION
It appears with Node v6 `GLOBAL` has been renamed to `global` per https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#globals