### PR TITLE
Fix for issue where replaced path is incorrect

### DIFF
--- a/src/tasks/VersionTask.js
+++ b/src/tasks/VersionTask.js
@@ -77,7 +77,7 @@ class VersionTask extends Elixir.Task {
 
         this.recordStep('Rewriting File Paths');
 
-        return $.revReplace({ prefix: buildFolder });
+        return $.revReplace({ prefix: buildFolder + '/' });
     }
 
 


### PR DESCRIPTION
This fixes a problem with `updateVersionedPathInFiles`, where the replacement path for assets referenced in files is concatenated incorrectly. For example, `images/example-9636dee185.png` becomes `buildimages/example-9636dee185.png`.