### PR TITLE
add `/` to buildPath

### DIFF
--- a/src/tasks/VersionTask.js
+++ b/src/tasks/VersionTask.js
@@ -120,7 +120,7 @@ class VersionTask extends Elixir.Task {
      * @param {string} srcMap
      */
     copyMap(srcMap) {
-        let destMap = srcMap.replace(this.publicPath, this.buildPath);
+        let destMap = srcMap.replace(this.publicPath, this.buildPath +'/');
 
         fs.createReadStream(`${srcMap}.map`)
           .pipe(fs.createWriteStream(`${destMap}.map`));


### PR DESCRIPTION
I'm not sure if anyone else is getting this sort of error, but today my `version` task kept breaking on me and it turned out the`buildPath` was missing a `/` when I made this change to my local version everything worked.

Screenshot of the error I was receiving: 
<img width="1020" alt="screen shot 2016-09-02 at 12 13 00 am" src="https://cloud.githubusercontent.com/assets/989648/18192435/36a96baa-70a2-11e6-9921-1c915ab3547c.png">

Note: 1) this is the default build folder and 2) when I changed the build folder, to `build/` it still didn't work. I needed to make this change in actual task. 

Thoughts?
