### PR TITLE
Added ability to configure watch

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -362,8 +362,23 @@ const config = {
         proxy: 'homestead.app',
         reloadOnRestart : true,
         notify: true
-    }
+    },
 
+    /*
+     |----------------------------------------------------------------
+     | Watch
+     |----------------------------------------------------------------
+     |
+     | Configure how your filesystem is monitored for changes. This
+     | modifies the behavior of any task using "watch."
+     |
+     */
+
+    watch: {
+        // https://www.npmjs.com/package/gulp-watch/#options
+        interval: 1000,
+        usePolling: true
+    }
 };
 
 /**

--- a/src/tasks/recipes/watch.js
+++ b/src/tasks/recipes/watch.js
@@ -18,9 +18,10 @@ gulp.task('watch', () => {
 
     Elixir.tasks.forEach(task => {
         let batchOptions = Elixir.config.batchOptions;
+        let watchOptions = Elixir.config.watch;
 
         if (task.hasWatchers()) {
-            gulp.watch(task.watchers, { interval: 1000, usePolling: true }, batch(batchOptions, events => {
+            gulp.watch(task.watchers, watchOptions, batch(batchOptions, events => {
                 events.on('end', gulp.start(task.name));
             }));
         }


### PR DESCRIPTION
Allow gulp watch to be configured. This addressed the problem in #586 for me on a Linux system as I was able to disable polling.

The defaults are the same as they were prior to this commit: polling at a 1s interval.

Thanks!