### PR TITLE
[VersionTask] Do not copy source maps to same path

### DIFF
--- a/src/tasks/VersionTask.js
+++ b/src/tasks/VersionTask.js
@@ -120,10 +120,12 @@ class VersionTask extends Elixir.Task {
      * @param {string} srcMap
      */
     copyMap(srcMap) {
-        let destMap = srcMap.replace(this.publicPath, this.buildPath +'/');
+        let destMap = srcMap.replace(this.publicPath, this.buildPath +'/').replace('//', '/');
 
-        fs.createReadStream(`${srcMap}.map`)
-          .pipe(fs.createWriteStream(`${destMap}.map`));
+        if (destMap != srcMap) {
+            fs.createReadStream(`${srcMap}.map`)
+              .pipe(fs.createWriteStream(`${destMap}.map`));
+        }
     }
 
 }


### PR DESCRIPTION
When using `.version([ ... ], 'public')` to store versioned files in the same folder as the original ones, then there is no need to copy the source maps to a new location.
In fact, the copying algorithm yields empty source maps, because `fs.createWriteStream` cannot read from the same file it writes to. So we have to check that case.

Note that I've put `.replace('//', '/')` to the path, this is due to the fact that the `destMap` will be something like `public//css/app.css` or `public/build//css/app.css` without that change replacement.
