### PR TITLE
Switch to vinyl-map2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.5",
     "underscore": "^1.8.3",
-    "vinyl-map": "^1.0.1"
+    "vinyl-map2": "^1.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",


### PR DESCRIPTION
vinyl-map seems to be unmaintained and it creates npm errors.

```
└─┬ laravel-elixir@6.0.0-11
  └─┬ vinyl-map@1.0.1
    ├── bl@0.7.0
    └── UNMET PEER DEPENDENCY stream-browserify@*

npm ERR! peer dep missing: stream-browserify@*, required by bl@0.7.0
```

I tried to run tests, but the command fails:

```
$ npm test

> laravel-elixir@6.0.0-11 test /tmp/elixir
> cd elixir-test-app && mocha --require babel-core/register --require=test/bootstrap.js

module.js:442
    throw err;
    ^

Error: Cannot find module 'laravel-elixir'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/tmp/elixir/elixir-test-app/test/bootstrap.js:1:1)
    at Module._compile (module.js:541:32)
    at loader (/tmp/elixir/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/tmp/elixir/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at /tmp/elixir/node_modules/mocha/bin/_mocha:311:3
    at Array.forEach (native)
    at Object.<anonymous> (/tmp/elixir/node_modules/mocha/bin/_mocha:310:10)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
npm ERR! Test failed.  See above for more details.
```