### PR TITLE
Fix gulp watch when multiple base paths specified

### DIFF
--- a/src/tasks/CssTask.js
+++ b/src/tasks/CssTask.js
@@ -39,7 +39,8 @@ class CssTask extends Elixir.Task {
      * Register file watchers.
      */
     registerWatchers() {
-        this.watch(this.src.baseDir + Elixir.config.css[this.name].search)
+        this.watch(this.src.path)
+            .watch(this.src.baseDir + Elixir.config.css[this.name].search)
             .ignore(this.output.path);
     }
 


### PR DESCRIPTION
I've been looking into an issue where some files aren't being watched when multiple files are specified via an array in either a `mix.sass()` or `mix.less()` task. At first, I thought it was on my end, but I was just able to reproduce it with a new 5.3 install (running on valet). Gulp isn't registering the correct watcher for both base paths.

Here's the example gulpfile to reproduce it:
```
const elixir = require('laravel-elixir');
require('laravel-elixir-vue-2');

elixir(mix => {
    mix.sass([
    	'app.scss',
    	'./example/sass/style.scss'
    ]);
});

```
With the above example, gulp only watches `resources/assets/sass/**`, the other file does not trigger the 'sass' task on save when the gulp watch task is running. Specifying a single file as a string for the first parameter of `mix.sass()` gets the intended watch effect, just not when there's an array passed in like in the example gulpfile. 

At first I thought maybe supporting a base path per input file might be the best choice, but I don't want to mess with anything elixir already supports. This solution makes sure there are watchers registered for the file(s) with paths outside the base path too.

Edit: I accidentally submitted this issue with a bogus title -- fixed now, but sorry for any confusion if notifications came through with the original (incomplete) title!