### PR TITLE
Fix for double gulp watching tasks

### DIFF
--- a/src/tasks/GulpBuilder.js
+++ b/src/tasks/GulpBuilder.js
@@ -38,6 +38,7 @@ class GulpBuilder {
             if (this.shouldRunAllTasksNamed(name)) {
                 return Elixir.tasks
                     .byName(name)
+                    .filter(task => !Elixir.tasks.watching || Elixir.tasks.watching === task)
                     .forEach(task => task.run());
             }
 

--- a/src/tasks/recipes/watch.js
+++ b/src/tasks/recipes/watch.js
@@ -20,7 +20,7 @@ gulp.task('watch', ['default'], () => {
 
         if (task.hasWatchers()) {
             gulp.watch(task.watchers, watchOptions, batch(batchOptions, events => {
-                events.on('end', gulp.start(task.name));
+                events.on('end', (Elixir.tasks.watching = task) && gulp.start(task.name));
             }));
         }
     });


### PR DESCRIPTION
This PR fixes a bug whereby watching tasks of the same name with the same watching directory means they will be fired exponentially!

This is because during `gulp watch` when a matching watcher file pattern triggers its task, then each task will then proceed to run all tasks with the same name.

By indicating that a particular task is currently being "watched" and flagging whether elixir is in "watch mode" or not, this PR attempts to only fire the task being watched (and not all with the same name) when elixir is in watch mode.

## Steps to reproduce the bug:
1. create 2 new files: `resources/assets/sass/a.scss` and `resources/assets/sass/b.scss` both with the contents:
    ```scss
    @import "app";
    ```
1. in your gulpfile:
    ```js
    elixir((mix) => {
        mix.sass('a.scss')
           .sass('b.scss');
    });
    ```
1. run `gulp watch`
1. You should see no problem at this point ✅
1. Make a change to `resources/assets/sass/app.scss`
1. check the terminal, you should see gulp has done compiled `a.scss` and `b.scss` twice! 🐛

## Steps to check this fixes it
1. Repeat the above steps with this branch checked out
1. Everything should now work as expected
