### PR TITLE
Revert "Fix for issue where replaced path is incorrect"

### DIFF
--- a/src/tasks/VersionTask.js
+++ b/src/tasks/VersionTask.js
@@ -77,7 +77,7 @@ class VersionTask extends Elixir.Task {
 
         this.recordStep('Rewriting File Paths');
 
-        return $.revReplace({ prefix: buildFolder + '/' });
+        return $.revReplace({ prefix: buildFolder });
     }
 
 


### PR DESCRIPTION
See example test case here (there is an extra slash):
https://github.com/sw-double/elixir-version-test/blob/master/public/build/css/app-3d4d0679e1.css

This reverts commit 567fcbf7c1d01f88ad3c4fb300116f1702e06e5c.
https://github.com/laravel/elixir/pull/597