### PR TITLE
Update gulp-uglify to fix syntax errors in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gulp-sass": "^2.3.2",
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^1.5.3",
+    "gulp-uglify": "^2.1.2",
     "gulp-util": "^3.0.7",
     "parse-filepath": "^1.0.1",
     "path": "^0.12.7",


### PR DESCRIPTION
Updating gulp-uglify to ^2.1.2 fixes errors like this on minified javascript in Safari as per this issue https://github.com/mishoo/UglifyJS2/issues/179

"SyntaxError: Cannot declare a parameter named 'e' as it shadows the name of a strict mode function"