### PR TITLE
chore: upgrade require-dir to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "parse-filepath": "^1.0.1",
     "path": "^0.12.7",
     "q": "^1.4.1",
-    "require-dir": "^0.3.0",
+    "require-dir": "^0.3.2",
     "run-sequence": "^1.1.5",
     "underscore": "^1.8.3",
     "vinyl-map2": "^1.2.1"


### PR DESCRIPTION
**TL;DR**: just manually install `require-dir@^0.3.2`

for yarn user: add `"resolutions": { "require-dir": "0.3.2" }` in your project's `package.json`

------
(original pull-request starts from here:)

so we can use laravel-elixir in node 8.x.x

ref aseemk/requireDir#46