### PR TITLE
Take the renaming into account

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Laravel Elixir
 
+Elixir has been renamed to Mix, see this news to know more: https://laravel-news.com/laravel-elixir-to-laravel-mix
+
 ## Introduction
 
 Laravel Elixir provides a clean, fluent API for defining basic Gulp tasks for your Laravel application. Elixir supports several common CSS and JavaScript pre-processors, and even testing tools.
@@ -8,7 +10,7 @@ If you've ever been confused about how to get started with Gulp and asset compil
 
 ## Official Documentation
 
-Documentation for Elixir can be found on the [Laravel website](http://laravel.com/docs/elixir).
+Documentation for Laravel Mix can be found on the [Laravel website](https://laravel.com/docs/5.4/mix).
 
 ## License
 


### PR DESCRIPTION
- Replace the documentation dead link
- Important: The top link of the package should also be replaced as it leads to a page that does not exists