### PR TITLE
Fixed official documentation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ If you've ever been confused about how to get started with Gulp and asset compil
 
 ## Official Documentation
 
-Documentation for Elixir can be found on the [Laravel website](http://laravel.com/docs/elixir).
+Documentation for Elixir can be found on the [Laravel website](http://laravel.com/docs/5.3/elixir).
 
 ## License
 


### PR DESCRIPTION
As Elixir was last referred in documentation on 5.3, [http://laravel.com/docs/elixir] returns 404 now. So updated the link to [http://laravel.com/docs/5.3/elixir].