### PR TITLE
Update gulp-sass to get a version of node-sass which works on alpine linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^7.0.0",
     "gulp-rev-replace": "^0.4.3",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "^3.1.0",
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.3",


### PR DESCRIPTION
gulp-sass v3.1.0 uses node-sass v4.2.0 prior to v4.1.0 node-sass [wouldn't install correctly on Alpine Linux](https://github.com/sass/node-sass/issues/1589)